### PR TITLE
Feature/클라이언트 타임아웃 조절

### DIFF
--- a/src/main/java/com/mapshot/api/domain/map/builder/MapBuildService.java
+++ b/src/main/java/com/mapshot/api/domain/map/builder/MapBuildService.java
@@ -20,9 +20,6 @@ public class MapBuildService {
     @Value("${lambda.host}")
     private String host;
 
-    @Value("${lambda.path}")
-    private String path;
-
     @Value("${jwt.image.header}")
     private String SERVER_HEADER_NAME;
 
@@ -30,7 +27,7 @@ public class MapBuildService {
     public List<MapBuildResponse> requestMapImage(MultiValueMap<String, String> queryParams) {
         queryParams.add(SERVER_HEADER_NAME, serverValidation.makeToken());
 
-        return lambdaClient.sendRequest(host, path, queryParams, MapBuildResponse[].class);
+        return lambdaClient.sendRequest(host, "", queryParams, MapBuildResponse[].class);
     }
 
 }

--- a/src/main/java/com/mapshot/api/infra/client/lambda/LambdaClient.java
+++ b/src/main/java/com/mapshot/api/infra/client/lambda/LambdaClient.java
@@ -16,7 +16,7 @@ public class LambdaClient {
     private final CommonClient client;
 
     public <T> List<T> sendRequest(String host, String path, MultiValueMap<String, String> queryParams, Class<T[]> clazz) {
-        long timeoutMillis = 30 * 1000L;
+        long timeoutMillis = 60 * 1000L;
 
         String url = UriComponentsBuilder.newInstance()
                 .scheme("https")

--- a/src/main/java/com/mapshot/api/infra/client/lambda/LambdaClient.java
+++ b/src/main/java/com/mapshot/api/infra/client/lambda/LambdaClient.java
@@ -3,6 +3,7 @@ package com.mapshot.api.infra.client.lambda;
 
 import com.mapshot.api.infra.client.CommonClient;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -15,8 +16,10 @@ public class LambdaClient {
 
     private final CommonClient client;
 
+    @Value("${lambda.timeout}")
+    private Long timeoutMillis;
+
     public <T> List<T> sendRequest(String host, String path, MultiValueMap<String, String> queryParams, Class<T[]> clazz) {
-        long timeoutMillis = 60 * 1000L;
 
         String url = UriComponentsBuilder.newInstance()
                 .scheme("https")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ server:
 
 lambda:
   host: ${lambdaHost}
-  path: ${lambdaPath}
+  timeout: ${lambdaTimeout}
 
 slack:
   url: ${slackUrl}

--- a/src/test/java/com/mapshot/api/infra/client/lambda/LambdaClientTest.java
+++ b/src/test/java/com/mapshot/api/infra/client/lambda/LambdaClientTest.java
@@ -29,9 +29,6 @@ class LambdaClientTest {
     @Value("${lambda.host}")
     private String host;
 
-    @Value("${lambda.path}")
-    private String path;
-
 
     @Test
     void 응답_형변환_테스트() {
@@ -49,7 +46,7 @@ class LambdaClientTest {
         when(commonClient.get(any(String.class), any(long.class), any(Class.class))).
                 thenReturn(lst.toArray());
 
-        List<MapBuildResponse> responses = lambdaClient.sendRequest(host, path, new LinkedMultiValueMap<>(), MapBuildResponse[].class);
+        List<MapBuildResponse> responses = lambdaClient.sendRequest(host, "", new LinkedMultiValueMap<>(), MapBuildResponse[].class);
 
         assertArrayEquals(responses.toArray(), lst.toArray());
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,7 +15,7 @@ spring:
 
 lambda:
   host: hello
-  path: hello
+  timeout: 60000
 
 slack:
   url: hello


### PR DESCRIPTION
# 의도

aws 람다 api 게이트웨이 걷어낼 예정, 타임아웃 제한시간 증가 가능해짐
기존 로그를 보면 30초에서 플러스 마이너스 500ms~1초 차이로 이미지를 다 못받아와서 에러로 튕기는 케이스들이 많았음.
메모리에 이미지 누적되면서 클리너 돌기 전까지 필요없는 데이터 쌓임.
api 게이트웨이 자체 정책이 30초가 최대라서 고민이었는데 람다에서 굳이 사용 안해도 되는걸 이제 앎. 엉엉
에러 빈도수 크게 줄어들 것으로 예상함

# 변경

클라이언트 타임아웃 시간 늘림 30s ->60s
