### PR TITLE
Feat/슬랙 이슈 수정

### DIFF
--- a/src/main/java/com/mapshot/api/infra/client/CommonClient.java
+++ b/src/main/java/com/mapshot/api/infra/client/CommonClient.java
@@ -1,6 +1,7 @@
 package com.mapshot.api.infra.client;
 
 import com.mapshot.api.infra.exception.ApiException;
+import com.mapshot.api.infra.exception.status.ErrorCode;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
@@ -49,7 +50,7 @@ public class CommonClient {
                     .block(Duration.ofMillis(timeoutMillis));
 
         } catch (Exception e) {
-            throw new ApiException(e.getMessage(), e);
+            throw new ApiException(ErrorCode.SERVER_TO_SERVER_ERROR);
         }
     }
 
@@ -67,7 +68,7 @@ public class CommonClient {
                     .block(Duration.ofMillis(timeoutMillis));
 
         } catch (Exception e) {
-            throw new ApiException(e.getMessage(), e);
+            throw new ApiException(ErrorCode.SERVER_TO_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/mapshot/api/infra/exception/ApiException.java
+++ b/src/main/java/com/mapshot/api/infra/exception/ApiException.java
@@ -6,19 +6,10 @@ import lombok.Getter;
 @Getter
 public class ApiException extends RuntimeException {
 
-    private StatusCode code;
-
-    public ApiException(String msg) {
-        super(msg);
-    }
+    private final StatusCode code;
 
     public ApiException(StatusCode code) {
         super(code.getMessage());
         this.code = code;
     }
-
-    public ApiException(String msg, Throwable e) {
-        super(msg, e);
-    }
-
 }

--- a/src/main/java/com/mapshot/api/infra/exception/status/ErrorCode.java
+++ b/src/main/java/com/mapshot/api/infra/exception/status/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode implements StatusCode {
     NO_SUCH_USER(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     NO_SUCH_ALGORITHM(HttpStatus.NOT_FOUND, "암호화 알고리즘 탐색 불가"),
     NO_PRE_AUTH(HttpStatus.INTERNAL_SERVER_ERROR, "PreAuth 탐색 불가"),
+    SERVER_TO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 간 통신 에러"),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
# 의도

5월 2일에 람다쪽에 에러 생겨서 502가 계속 발생했었음, 근데 슬랙이 안 옴.
다행인게 느낌이 싸해서 아침에 그라파나 모니터링하다가 호출 시퀀스가 이상하게 돌아가는 느낌을 받음.
사이트 들어가서 지도 생성 눌러보니 역시나 서버 터져있음.

원인은

```java
    @ExceptionHandler(ApiException.class)
    public ResponseEntity<String> apiExceptionHandler(ApiException e) {
        StatusCode code = e.getCode();
        log.error(code.getMessage(), e);  // 문제 부분
        slackClient.sendMessage(e);

        return ResponseEntity.status(code.getHttpStatus())
                .body(code.getMessage());
    }
```

여기서 로깅 후 슬랙 메세지를 전송하는데 StatusCode의 메세지가 null값인 상태로 계속 webclient 예와가 터지고 있었음.
그래서 슬랙클라이언트 메세지 전송부분까지 컨텍스트가 닿지를 못함.
ApiException의 에러 메세지 삽입을 조금 더 유연하게 하는 방식으로 코드를 변경할까 하다가
얘는 서버에서 미리 정의한 에러기 때문에 차라리 더 엄격하게 관리하는게 낫겠다고 판단함.

그래서 ApiException 생성자 등등 이것저것 변경함.

# 변경

미리 정의된 예외는 조금 더 명확하게 생성할 수 있도록 변경함.

