### PR TITLE
Feat/뉴스 보완

### DIFF
--- a/src/main/java/com/mapshot/api/domain/news/NewsService.java
+++ b/src/main/java/com/mapshot/api/domain/news/NewsService.java
@@ -78,8 +78,22 @@ public class NewsService {
         postService.save("헤드샷", contents.toString(), "[" + LocalDate.now() + "] 오늘의 헤드라인", UUID.randomUUID().toString());
     }
 
+    public String removeBigBracket(String str) {
+        if (str.contains("[")) {
+            StringBuilder sb = new StringBuilder(str);
+            int startIndex = sb.indexOf("[");
+            int endIndex = sb.indexOf("]");
 
-    private String wrapHtmlTag(String content, String tag) {
+            sb.delete(startIndex, endIndex + 1);
+            
+            return sb.toString();
+        }
+
+        return str;
+    }
+
+
+    public String wrapHtmlTag(String content, String tag) {
         StringBuilder sb = new StringBuilder();
 
         sb.append("<");
@@ -95,7 +109,7 @@ public class NewsService {
     }
 
 
-    private String wrapHtmlTag(String content, String tag, Map<String, String> attr) {
+    public String wrapHtmlTag(String content, String tag, Map<String, String> attr) {
         StringBuilder sb = new StringBuilder();
 
         sb.append("<");
@@ -119,7 +133,7 @@ public class NewsService {
     }
 
 
-    private String getMetaImage(String url) {
+    public String getMetaImage(String url) {
         Document document = null;
 
         try {

--- a/src/test/java/com/mapshot/api/domain/news/NewsServiceTest.java
+++ b/src/test/java/com/mapshot/api/domain/news/NewsServiceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
@@ -18,6 +20,25 @@ class NewsServiceTest {
         String target = "[차관동정] 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진";
         String result = newsService.removeBigBracket(target);
         String expected = " 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진";
+
+        assertEquals(result, expected);
+    }
+
+
+    @Test
+    void 문자열을_html_태그로_감싼다() {
+        String target = "[차관동정] 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진";
+        String result = newsService.wrapHtmlTag(target, "p");
+        String expected = "<p>[차관동정] 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진</p>";
+
+        assertEquals(result, expected);
+    }
+
+    @Test
+    void 문자열을_html_태그로_감싸면서_속성값을_준다() {
+        String target = "[차관동정] 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진";
+        String result = newsService.wrapHtmlTag(target, "a", Map.of("href", "http://hello.com"));
+        String expected = "<a href=http://hello.com>[차관동정] 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진</a>";
 
         assertEquals(result, expected);
     }

--- a/src/test/java/com/mapshot/api/domain/news/NewsServiceTest.java
+++ b/src/test/java/com/mapshot/api/domain/news/NewsServiceTest.java
@@ -1,0 +1,24 @@
+package com.mapshot.api.domain.news;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class NewsServiceTest {
+
+    @Autowired
+    private NewsService newsService;
+
+
+    @Test
+    void 검색_정확도를_위해_대괄호_안의_문자열은_제거한다() {
+        String target = "[차관동정] 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진";
+        String result = newsService.removeBigBracket(target);
+        String expected = " 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진";
+
+        assertEquals(result, expected);
+    }
+}


### PR DESCRIPTION
# 의도

보도자료 타이틀이 대괄호로 감싸져 있으면 기사 검색이 어려움.
ex) [차관동정] 국토교통부, 고흥·울진·안동 신규 국가산단 예타 본격 추진
검색어 필터링이 필요할 듯

# 변경

대괄호 검색어 필터링 및 테스트 코드 추가
