### PR TITLE
Feat/어드민 게시글 삭제

### DIFF
--- a/src/main/java/com/mapshot/api/application/admin/AdminUseCase.java
+++ b/src/main/java/com/mapshot/api/application/admin/AdminUseCase.java
@@ -1,6 +1,7 @@
 package com.mapshot.api.application.admin;
 
 import com.mapshot.api.domain.admin.user.AdminUserService;
+import com.mapshot.api.domain.community.comment.CommentService;
 import com.mapshot.api.domain.community.post.PostService;
 import com.mapshot.api.domain.news.NewsService;
 import com.mapshot.api.domain.notice.NoticeService;
@@ -18,6 +19,7 @@ public class AdminUseCase {
 
     private final AdminUserService adminUserService;
     private final NoticeService noticeService;
+    private final CommentService commentService;
     private final PostService postService;
     private final NewsService newsService;
 
@@ -46,7 +48,7 @@ public class AdminUseCase {
     public void modifyNotice(long id, NoticeType type, String title, String content) {
         noticeService.update(id, type, title, content);
     }
-    
+
     public void forceNewsUpdate() {
         String content = newsService.getNewsContent();
         String writer = "헤드샷";
@@ -54,5 +56,10 @@ public class AdminUseCase {
         String password = UUID.randomUUID().toString();
 
         postService.save(writer, content, title, password);
+    }
+
+    public void forcePostDelete(long postId) {
+        postService.deleteById(postId);
+        commentService.deleteByPostId(postId);
     }
 }

--- a/src/main/java/com/mapshot/api/application/admin/AdminUseCase.java
+++ b/src/main/java/com/mapshot/api/application/admin/AdminUseCase.java
@@ -24,10 +24,6 @@ public class AdminUseCase {
     private final NewsService newsService;
 
 
-    public void deletePost(long postId) {
-        postService.deleteById(postId);
-    }
-
     public HttpHeaders login(String nickname, String password) {
         adminUserService.validationCheck(nickname, password);
         return adminUserService.getAuthHeader();
@@ -58,7 +54,7 @@ public class AdminUseCase {
         postService.save(writer, content, title, password);
     }
 
-    public void forcePostDelete(long postId) {
+    public void deletePost(long postId) {
         postService.deleteById(postId);
         commentService.deleteByPostId(postId);
     }

--- a/src/main/java/com/mapshot/api/domain/community/post/PostService.java
+++ b/src/main/java/com/mapshot/api/domain/community/post/PostService.java
@@ -105,7 +105,11 @@ public class PostService {
 
     @Transactional
     public void deleteById(long id) {
-        postRepository.deleteById(id);
+        PostEntity post = postRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.NO_SUCH_POST));
+
+        post.softDelete();
+        postRepository.save(post);
     }
 
 

--- a/src/main/java/com/mapshot/api/presentation/admin/AdminController.java
+++ b/src/main/java/com/mapshot/api/presentation/admin/AdminController.java
@@ -78,7 +78,7 @@ public class AdminController {
 
 
     @PreAuth(Accessible.ADMIN)
-    @PostMapping("/post/delete/{postId}")
+    @GetMapping("/post/delete/{postId}")
     public ResponseEntity<Void> deletePost(@PositiveOrZero @PathVariable(value = "postId") long postId) {
         adminUseCase.deletePost(postId);
 

--- a/src/main/java/com/mapshot/api/presentation/admin/AdminController.java
+++ b/src/main/java/com/mapshot/api/presentation/admin/AdminController.java
@@ -4,7 +4,6 @@ import com.mapshot.api.application.admin.AdminUseCase;
 import com.mapshot.api.domain.notice.NoticeType;
 import com.mapshot.api.infra.auth.annotation.PreAuth;
 import com.mapshot.api.infra.auth.enums.Accessible;
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -20,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
     private final AdminUseCase adminUseCase;
-    
+
     @PreAuth(Accessible.EVERYONE)
     @PostMapping("/user/login")
     public ResponseEntity<Void> login(@RequestBody AdminUserRequest request) {
@@ -39,14 +38,6 @@ public class AdminController {
         return ResponseEntity.ok()
                 .headers(authHeader)
                 .build();
-    }
-
-    @PreAuth(Accessible.ADMIN)
-    @GetMapping("/post/delete/{postNumber}")
-    public ResponseEntity<Void> deletePost(@Positive @PathVariable(value = "postNumber") long postNumber) {
-        adminUseCase.deletePost(postNumber);
-
-        return ResponseEntity.ok().build();
     }
 
 
@@ -81,6 +72,15 @@ public class AdminController {
     @GetMapping("/news/update")
     public ResponseEntity<Void> updateNewsLetter() {
         adminUseCase.forceNewsUpdate();
+
+        return ResponseEntity.ok().build();
+    }
+
+
+    @PreAuth(Accessible.ADMIN)
+    @PostMapping("/post/delete/{postId}")
+    public ResponseEntity<Void> deletePost(@PositiveOrZero @PathVariable(value = "postId") long postId) {
+        adminUseCase.deletePost(postId);
 
         return ResponseEntity.ok().build();
     }

--- a/src/test/java/com/mapshot/api/application/admin/AdminUseCaseTest.java
+++ b/src/test/java/com/mapshot/api/application/admin/AdminUseCaseTest.java
@@ -1,0 +1,58 @@
+package com.mapshot.api.application.admin;
+
+import com.mapshot.api.domain.community.comment.CommentEntity;
+import com.mapshot.api.domain.community.comment.CommentService;
+import com.mapshot.api.domain.community.post.PostService;
+import com.mapshot.api.infra.exception.ApiException;
+import com.mapshot.api.infra.exception.status.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class AdminUseCaseTest {
+
+    @Autowired
+    private AdminUseCase adminUseCase;
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private CommentService commentService;
+
+    @BeforeEach
+    void init() {
+        for (int i = 1; i < 10; i++) {
+
+            String value = Integer.toString(i);
+
+            long postId = postService.save(value, value, value, value);
+            
+            for (int j = 0; j < 100; j++) {
+                commentService.save(value, value, postId, value);
+            }
+        }
+    }
+
+    @Test
+    void 관리자_권한으로_게시글_삭제_테스트() {
+        long postId = postService.getPostsByPageNumber(0).getContent().get(0).getId();
+
+        adminUseCase.deletePost(postId);
+
+        assertThatThrownBy(() -> postService.getPostById(postId))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(ErrorCode.NO_SUCH_POST.getMessage());
+
+        Page<CommentEntity> comments = commentService.findAllByPostId(0, postId);
+
+        assertEquals(comments.getTotalPages(), 0);
+        assertEquals(comments.getContent().size(), 0);
+    }
+}

--- a/src/test/java/com/mapshot/api/application/admin/AdminUseCaseTest.java
+++ b/src/test/java/com/mapshot/api/application/admin/AdminUseCaseTest.java
@@ -1,16 +1,23 @@
 package com.mapshot.api.application.admin;
 
+import com.mapshot.api.domain.admin.user.AdminUserEntity;
+import com.mapshot.api.domain.admin.user.AdminUserRepository;
 import com.mapshot.api.domain.community.comment.CommentEntity;
+import com.mapshot.api.domain.community.comment.CommentRepository;
 import com.mapshot.api.domain.community.comment.CommentService;
+import com.mapshot.api.domain.community.post.PostRepository;
 import com.mapshot.api.domain.community.post.PostService;
+import com.mapshot.api.infra.encrypt.EncryptUtil;
 import com.mapshot.api.infra.exception.ApiException;
 import com.mapshot.api.infra.exception.status.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,6 +33,15 @@ class AdminUseCaseTest {
     @Autowired
     private CommentService commentService;
 
+    @Autowired
+    private AdminUserRepository adminUserRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
     @BeforeEach
     void init() {
         for (int i = 1; i < 10; i++) {
@@ -33,12 +49,26 @@ class AdminUseCaseTest {
             String value = Integer.toString(i);
 
             long postId = postService.save(value, value, value, value);
-            
+
             for (int j = 0; j < 100; j++) {
                 commentService.save(value, value, postId, value);
             }
         }
+
+        adminUserRepository.save(
+                AdminUserEntity.builder()
+                        .nickname("hello")
+                        .password(EncryptUtil.encrypt("1234"))
+                        .build());
     }
+
+    @AfterEach
+    void release() {
+        adminUserRepository.deleteAll();
+        postRepository.deleteAll();
+        commentRepository.deleteAll();
+    }
+
 
     @Test
     void 관리자_권한으로_게시글_삭제_테스트() {
@@ -54,5 +84,11 @@ class AdminUseCaseTest {
 
         assertEquals(comments.getTotalPages(), 0);
         assertEquals(comments.getContent().size(), 0);
+    }
+
+    @Test
+    void 관리자_로그인() {
+        assertThatNoException()
+                .isThrownBy(() -> adminUseCase.login("hello", "1234"));
     }
 }


### PR DESCRIPTION
# 의도

어드민 커뮤니티 게시글 강제 삭제 기능 추가

# 변경

관련 테스트 코드 추가, 기존 정책에 안 맞게 구현되어있던 삭제 방식 수정
