### PR TITLE
Feat/뉴스 수집 보완

### DIFF
--- a/src/main/java/com/mapshot/api/application/news/NewsUpdateScheduler.java
+++ b/src/main/java/com/mapshot/api/application/news/NewsUpdateScheduler.java
@@ -20,6 +20,11 @@ public class NewsUpdateScheduler {
     @Scheduled(cron = "0 0 21 * * *")
     public void update() {
         String content = newsService.getNewsContent();
+
+        if (content.isBlank()) {
+            return;
+        }
+        
         String writer = "헤드샷";
         String title = "[" + LocalDate.now() + "] 오늘의 헤드라인";
         String password = UUID.randomUUID().toString();

--- a/src/main/java/com/mapshot/api/domain/news/NewsService.java
+++ b/src/main/java/com/mapshot/api/domain/news/NewsService.java
@@ -42,13 +42,13 @@ public class NewsService {
         StringBuilder contents = new StringBuilder();
 
         for (NaverNewsResponse i : newsResponses) {
-            if (i.getItems().isEmpty()) {
+            if (i.getItems().isEmpty() || i.getTotal() == 0) {
                 continue;
             }
 
             NaverNewsDto detailNews = i.getItems().get(0);
 
-            if(detailNews.getPubDate().isBefore(LocalDateTime.now().minusDays(1))){
+            if (detailNews.getPubDate().isBefore(LocalDateTime.now().minusDays(1))) {
                 continue;
             }
 

--- a/src/main/java/com/mapshot/api/domain/news/NewsService.java
+++ b/src/main/java/com/mapshot/api/domain/news/NewsService.java
@@ -9,6 +9,7 @@ import com.mapshot.api.infra.util.HtmlTagUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,11 @@ public class NewsService {
             }
 
             NaverNewsDto detailNews = i.getItems().get(0);
+
+            if(detailNews.getPubDate().isBefore(LocalDateTime.now().minusDays(1))){
+                continue;
+            }
+
             contents.append(makeNewsContentForm(index++, detailNews));
         }
 

--- a/src/main/java/com/mapshot/api/domain/news/client/naver/NaverNewsDto.java
+++ b/src/main/java/com/mapshot/api/domain/news/client/naver/NaverNewsDto.java
@@ -19,7 +19,7 @@ public class NaverNewsDto {
     private String description;
     private String pubDate;
 
-    public LocalDateTime getPubDateTime() {
+    public LocalDateTime getPubDate() {
         return LocalDateTime.parse(pubDate, DateTimeFormatter.RFC_1123_DATE_TIME);
     }
 }

--- a/src/test/java/com/mapshot/api/application/news/NewsUpdateSchedulerTest.java
+++ b/src/test/java/com/mapshot/api/application/news/NewsUpdateSchedulerTest.java
@@ -1,0 +1,56 @@
+package com.mapshot.api.application.news;
+
+import com.mapshot.api.domain.community.post.PostRepository;
+import com.mapshot.api.domain.news.NewsService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class NewsUpdateSchedulerTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @MockBean
+    private NewsService newsService;
+
+    @Autowired
+    private NewsUpdateScheduler newsUpdateScheduler;
+
+    @BeforeEach
+    void init() {
+        postRepository.deleteAll();
+    }
+
+    @AfterEach
+    void release() {
+        postRepository.deleteAll();
+    }
+
+    @Test
+    void 발행된_뉴스가_없다면_글을_게시하지_않음() {
+        when(newsService.getNewsContent()).
+                thenReturn("");
+
+        newsUpdateScheduler.update();
+
+        assertEquals(postRepository.count(), 0);
+    }
+
+    @Test
+    void 뉴스가_존재하면_글을_게시함() {
+        when(newsService.getNewsContent()).
+                thenReturn("뉴스뉴스");
+
+        newsUpdateScheduler.update();
+
+        assertEquals(postRepository.count(), 1);
+    }
+}


### PR DESCRIPTION
# 의도

보도자료가 올라오고 추가 기사가 발행되기까지 어느 정도 시간이 필요한데,
만약 발행 시각까지 기사가 올라오지 않는다면 해당 보도자료는 관련 기사가 존재하지 않기 때문에
당일날 뉴스 레터에 포함되면 안됨.

그런데 가끔 예전에 발행된 비슷한 키워드의 기사를 긁어오는 바람에 데이터가 오염되고 있음.
날짜 비교 후 예전 기사라면 뉴스레터에 포함시키지 않는 방식으로 코드 변경

# 변경

날짜 확인 코드 추가
