### PR TITLE
Feat/로그 수집

### DIFF
--- a/src/main/java/com/mapshot/api/application/log/LogUseCase.java
+++ b/src/main/java/com/mapshot/api/application/log/LogUseCase.java
@@ -1,0 +1,17 @@
+package com.mapshot.api.application.log;
+
+import com.mapshot.api.domain.log.LogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LogUseCase {
+
+    private final LogService logService;
+
+    public void collectLog(String roll, String stackTrace) {
+        logService.write(roll, stackTrace);
+        logService.alert(roll, stackTrace);
+    }
+}

--- a/src/main/java/com/mapshot/api/domain/log/LogService.java
+++ b/src/main/java/com/mapshot/api/domain/log/LogService.java
@@ -1,0 +1,25 @@
+package com.mapshot.api.domain.log;
+
+import com.mapshot.api.infra.client.slack.SlackClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LogService {
+
+    private final SlackClient slackClient;
+
+    public void write(String roll, String stackTrace) {
+        log.error("{} {}", roll, stackTrace);
+    }
+
+
+    public void alert(String roll, String stackTrace) {
+        String title = roll + " 서버 에러";
+        slackClient.sendMessage(title, stackTrace);
+    }
+
+}

--- a/src/main/java/com/mapshot/api/infra/client/slack/SlackClient.java
+++ b/src/main/java/com/mapshot/api/infra/client/slack/SlackClient.java
@@ -20,6 +20,15 @@ public class SlackClient {
 
     private final WebClient slackRestClient;
 
+    public void sendMessage(String title, String message) {
+        SlackMessage slackMessage = SlackMessage.builder()
+                .title(title)
+                .message(makeTransmissible(message))
+                .build();
+
+        sendSlackMessage(slackMessage);
+    }
+
     public void sendMessage(ApiException e) {
         SlackMessage slackMessage = SlackMessage.builder()
                 .title(e.getCode().getMessage())
@@ -40,6 +49,11 @@ public class SlackClient {
 
     private String makeTransmissible(Throwable e) {
         String stackTrace = Arrays.toString(e.getStackTrace());
+        
+        return makeTransmissible(stackTrace);
+    }
+
+    private String makeTransmissible(String stackTrace) {
         int len = Math.min(stackTrace.length(), 1700);
 
         return stackTrace.substring(0, len);

--- a/src/main/java/com/mapshot/api/presentation/externalLog/ExternalLogCollectorController.java
+++ b/src/main/java/com/mapshot/api/presentation/externalLog/ExternalLogCollectorController.java
@@ -5,6 +5,7 @@ import com.mapshot.api.infra.auth.annotation.PreAuth;
 import com.mapshot.api.infra.auth.enums.Accessible;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +18,7 @@ public class ExternalLogCollectorController {
 
     @PreAuth(Accessible.FRIENDLY_SERVER)
     @PostMapping
-    public void collectExternalLog(LogRequest request) {
+    public void collectExternalLog(@RequestBody LogRequest request) {
         logUseCase.collectLog(request.getRoll(), request.getStackTrace());
     }
 }

--- a/src/main/java/com/mapshot/api/presentation/externalLog/ExternalLogCollectorController.java
+++ b/src/main/java/com/mapshot/api/presentation/externalLog/ExternalLogCollectorController.java
@@ -1,0 +1,23 @@
+package com.mapshot.api.presentation.externalLog;
+
+import com.mapshot.api.application.log.LogUseCase;
+import com.mapshot.api.infra.auth.annotation.PreAuth;
+import com.mapshot.api.infra.auth.enums.Accessible;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/log")
+@RequiredArgsConstructor
+public class ExternalLogCollectorController {
+
+    private final LogUseCase logUseCase;
+
+    @PreAuth(Accessible.FRIENDLY_SERVER)
+    @PostMapping
+    public void collectExternalLog(LogRequest request) {
+        logUseCase.collectLog(request.getRoll(), request.getStackTrace());
+    }
+}

--- a/src/main/java/com/mapshot/api/presentation/externalLog/LogRequest.java
+++ b/src/main/java/com/mapshot/api/presentation/externalLog/LogRequest.java
@@ -1,0 +1,15 @@
+package com.mapshot.api.presentation.externalLog;
+
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class LogRequest {
+    private String roll;
+    private String stackTrace;
+}

--- a/src/test/java/com/mapshot/api/application/log/LogUseCaseTest.java
+++ b/src/test/java/com/mapshot/api/application/log/LogUseCaseTest.java
@@ -1,0 +1,26 @@
+package com.mapshot.api.application.log;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ExtendWith(OutputCaptureExtension.class)
+class LogUseCaseTest {
+
+    @Autowired
+    private LogUseCase logUseCase;
+
+
+    @Test
+    void 로그_수집_후_슬랙으로_전송한다(CapturedOutput output) {
+        logUseCase.collectLog("testRoll", "testStackTrace");
+        assertThat(output).contains("testRoll", "testStackTrace");
+    }
+
+}

--- a/src/test/java/com/mapshot/api/domain/log/LogServiceTest.java
+++ b/src/test/java/com/mapshot/api/domain/log/LogServiceTest.java
@@ -1,0 +1,24 @@
+package com.mapshot.api.domain.log;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ExtendWith(OutputCaptureExtension.class)
+class LogServiceTest {
+
+    @Autowired
+    private LogService logService;
+
+    @Test
+    public void 로그_작성_테스트(CapturedOutput output) {
+        logService.write("testRoll", "testLog");
+        assertThat(output).contains("testRoll", "testLog");
+    }
+}

--- a/src/test/java/com/mapshot/api/presentation/externalLog/ExternalLogCollectorControllerTest.java
+++ b/src/test/java/com/mapshot/api/presentation/externalLog/ExternalLogCollectorControllerTest.java
@@ -1,0 +1,59 @@
+package com.mapshot.api.presentation.externalLog;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mapshot.api.infra.auth.ServerValidation;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+class ExternalLogCollectorControllerTest {
+
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private ServerValidation validation;
+
+    @Test
+    void 로그_수집_요청() throws Exception {
+
+        LogRequest request = LogRequest.builder()
+                .roll("testRoll")
+                .stackTrace("testStackTrace")
+                .build();
+
+
+        mockMvc.perform(post("/log")
+                        .headers(validation.makeHeader())
+                        .content(mapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("log",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("roll").description("에러가 발생한 서버의 역할, 기능"),
+                                fieldWithPath("stackTrace").description("에러 스택트레이스")
+                        )))
+                .andReturn();
+
+    }
+}


### PR DESCRIPTION
# 의도

람다 쪽에서 에러나는게 감지가 어려움.
그라파나에서 모니터링하다가 에러 보이면 aws 접속해서 클라우드워치 뜯어봐야하는데 귀찮음
ec2에 로그 몰빵해서 에러나면 바로 슬랙 전송하게 하려고 함

# 변경

외부 로그 수집 컨트롤러 추가
람다 관련 게이트웨이 용도 컨트롤러 추가 예정(토큰 심어주고, 로그 전송 시 인증용도로 활용 예정 아마도?)